### PR TITLE
Encrypt SQS queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To build and deploy your application for the first time, run the following in yo
 
 ```bash
 sam build --use-container
-sam deploy --guided
+sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
 ```
 
 The first command will build the source of your application. The second command will package and deploy your application to AWS, with a series of prompts:
@@ -44,7 +44,7 @@ The first command will build the source of your application. The second command 
 * **Stack Name**: The name of the stack to deploy to CloudFormation. This should be unique to your account and region, and a good starting point would be something matching your project name.
 * **AWS Region**: The AWS region you want to deploy your app to.
 * **Confirm changes before deploy**: If set to yes, any change sets will be shown to you before execution for manual review. If set to no, the AWS SAM CLI will automatically deploy application changes.
-* **Allow SAM CLI IAM role creation**: Many AWS SAM templates, including this example, create AWS IAM roles required for the AWS Lambda function(s) included to access AWS services. By default, these are scoped down to minimum required permissions. To deploy an AWS CloudFormation stack which creates or modified IAM roles, the `CAPABILITY_IAM` value for `capabilities` must be provided. If permission isn't provided through this prompt, to deploy this example you must explicitly pass `--capabilities CAPABILITY_IAM` to the `sam deploy` command.
+* **Allow SAM CLI IAM role creation**: Many AWS SAM templates, including this example, create AWS IAM roles required for the AWS Lambda function(s) included to access AWS services. By default, these are scoped down to minimum required permissions. To deploy an AWS CloudFormation stack which creates or modified IAM roles, the `CAPABILITY_IAM` value for `capabilities` must be provided. If permission isn't provided through this prompt, to deploy this example you must explicitly pass ` --capabilities CAPABILITY_NAMED_IAM` to the `sam deploy` command.
 * **Save arguments to samconfig.toml**: If set to yes, your choices will be saved to a configuration file inside the project, so that in the future you can just re-run `sam deploy` without parameters to deploy changes to your application.
 
 You can find your API Gateway Endpoint URL in the output values displayed after deployment.

--- a/template.yaml
+++ b/template.yaml
@@ -17,18 +17,134 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['amazon-pinpoint', 'pinpoint', 'custom-channel', 'voice', 'python']
     HomePageUrl: https://aws.amazon.com/pinpoint
-    SemanticVersion: 1.0.0
+    SemanticVersion: 1.0.1
     SourceCodeUrl: https://github.com/aws-samples/amazon-pinpoint-voice-channel
 
 Resources:
   VoiceSQSQueue:
     Type: AWS::SQS::Queue
+    DependsOn: "VoiceSQSQueueCMK"
     Properties:
       VisibilityTimeout: 100
       FifoQueue: true
+      KmsMasterKeyId:
+        Ref: VoiceSQSQueueCMK
+      KmsDataKeyReusePeriodSeconds: 600
+
+  PinpointVoiceQueuerFunctionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName:
+        Fn::Sub: "${AWS::Region}-PinpointVoiceQueuerFunctionRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: PinpointVoiceQueuerPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: WriteSQS
+                Effect: Allow
+                Action: sqs:SendMessage
+                Resource: "*"
+
+  PinpointVoiceChannelFunctionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName:
+        Fn::Sub: "${AWS::Region}-PinpointVoiceChannelFunctionRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: PinpointVoiceChannelFunctionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: SendVoiceMessage
+                Effect: Allow
+                Action: sms-voice:SendVoiceMessage
+                Resource: !Sub arn:aws:sms-voice:${AWS::Region}:${AWS::AccountId}:/v1/sms-voice/voice/message
+              - Sid: PinpointPutEvents
+                Effect: Allow
+                Action: mobiletargeting:PutEvents
+                Resource: !Sub arn:${AWS::Partition}:mobiletargeting:${AWS::Region}:${AWS::AccountId}:*
+              - Sid: DecryptMessage
+                Effect: Allow
+                Action: ['kms:Decrypt', 'kms:GenerateDataKey']
+                Resource: "*"
+
+  VoiceSQSQueueCMK:
+    Type: "AWS::KMS::Key"
+    DependsOn:
+      - "PinpointVoiceQueuerFunctionRole"
+      - "PinpointVoiceChannelFunctionRole"
+    Properties:
+      Description: 'CMK used for encryption/decryption of queue VoiceSQSQueue.'
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: VoiceSQSQueueCMK'
+        Statement:
+          -
+            Sid: 'Allow administration of the key'
+            Effect: Allow
+            Principal:
+              AWS:
+                - Fn::Sub: 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+            Action:
+              - 'kms:Create*'
+              - 'kms:Describe*'
+              - 'kms:Enable*'
+              - 'kms:List*'
+              - 'kms:Put*'
+              - 'kms:Update*'
+              - 'kms:Revoke*'
+              - 'kms:Disable*'
+              - 'kms:Get*'
+              - 'kms:Delete*'
+              - 'kms:ScheduleKeyDeletion'
+              - 'kms:CancelKeyDeletion'
+            Resource: '*'
+          -
+            Sid: 'Allow use of the key'
+            Effect: Allow
+            Principal:
+              AWS:
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::Region}-PinpointVoiceQueuerFunctionRole"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::Region}-PinpointVoiceChannelFunctionRole"
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+              - 'kms:ReEncrypt*'
+              - 'kms:GenerateDataKey*'
+              - 'kms:DescribeKey'
+            Resource: '*'
 
   PinpointVoiceQueuerFunction:
     Type: AWS::Serverless::Function
+    DependsOn: "VoiceSQSQueueCMK"
     Properties:
       FunctionName: AmazonPinpointVoiceChannel
       CodeUri: voicequeuer/
@@ -39,12 +155,7 @@ Resources:
         Variables:
           SQS_QUEUE_URL: !Ref VoiceSQSQueue
           PINPOINT_LONG_CODES: !Ref PINPOINTLONGCODES
-      Policies:
-        - Statement:
-          - Sid: WriteSQS
-            Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt VoiceSQSQueue.Arn
+      Role: !GetAtt PinpointVoiceQueuerFunctionRole.Arn
 
 
   PinpointVoiceChannelFunction:
@@ -62,16 +173,7 @@ Resources:
           Properties:
             Queue: !GetAtt VoiceSQSQueue.Arn
             BatchSize: 10
-      Policies:
-        - Statement:
-          - Sid: SendVoiceMessage
-            Effect: Allow
-            Action: sms-voice:SendVoiceMessage
-            Resource: !Sub arn:aws:sms-voice:${AWS::Region}:${AWS::AccountId}:/v1/sms-voice/voice/message
-          - Sid: PinpointPutEvents
-            Effect: Allow
-            Action: mobiletargeting:PutEvents
-            Resource: !Sub arn:${AWS::Partition}:mobiletargeting:${AWS::Region}:${AWS::AccountId}:*
+      Role: !GetAtt PinpointVoiceChannelFunctionRole.Arn
 
 
   PinpointInvokePermission:


### PR DESCRIPTION

*Issue #, if available:*
https://t.corp.amazon.com/V370838054
AWS AppSec Finding: SQS queue without encryption

*Description of changes:*
Encrypted SQS queue
was able to test by sam deploy this change, use the lambda from pinpoint console campaign, and receive voice call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
